### PR TITLE
Fix README build from source wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ That's it! Now you can use `oscl` from anywhere.
 
 ### Build from source (Alternative)
 
-If you prefer building manually or are not using Homebrew, you can build visp from source.
+If you prefer building manually or are not using Homebrew, you can build oscl from source.
 
 You will need [Roswell](https://github.com/roswell/roswell) and [SBCL](http://www.sbcl.org/) installed.
 


### PR DESCRIPTION
## Summary
- correct wording in build instructions to reference oscl instead of visp

## Testing
- `make test` *(fails: `ros` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400019e848832485f92a12ecd4b6c9