### PR TITLE
Add padded buffer case for parse-osc-str

### DIFF
--- a/t/test-parser.lisp
+++ b/t/test-parser.lisp
@@ -9,6 +9,15 @@
          (next nil))
     (multiple-value-setq (str next) (parse-osc-str buf 0))
     (ok (string= str "/test"))
+    (ok (= next 8)))
+
+  ;; string length exactly 4 should still advance index to 8
+  (let* ((buf (make-array 8 :element-type '(unsigned-byte 8)
+                         :initial-contents #(97 98 99 100 0 0 0 0))) ; "abcd\0\0\0"
+         (str nil)
+         (next nil))
+    (multiple-value-setq (str next) (parse-osc-str buf 0))
+    (ok (string= str "abcd"))
     (ok (= next 8))))
 
 (deftest parse-osc-int-test


### PR DESCRIPTION
## Summary
- extend `parse-osc-str-test` with an additional buffer example
- check that a four character string padded with zeros advances to index 8

## Testing
- `make test` *(fails: ros not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840005668e083249c7f3af02e791aa0